### PR TITLE
renaming indices so that plugin will work with sqlite

### DIFF
--- a/db/migrate/20131123172825_create_asset_attachments.rb
+++ b/db/migrate/20131123172825_create_asset_attachments.rb
@@ -8,7 +8,7 @@ class CreateAssetAttachments < ActiveRecord::Migration
     end
 
     add_index :assetable_asset_attachments, :asset_id
-    add_index :assetable_asset_attachments, [:assetable_type, :assetable_id], name: "poly_asset"
+    add_index :assetable_asset_attachments, [:assetable_type, :assetable_id], name: "poly_asset_attachment"
     add_index :assetable_asset_attachments, [:assetable_type, :assetable_id, :name], unique: true, name: "named_asset"
     add_index :assetable_asset_attachments, :assetable_id
   end

--- a/db/migrate/20131125200943_create_galleries.rb
+++ b/db/migrate/20131125200943_create_galleries.rb
@@ -6,7 +6,7 @@ class CreateGalleries < ActiveRecord::Migration
       t.timestamps
     end
 
-    add_index :assetable_galleries, [:galleryable_type, :galleryable_id], name: "poly_asset"
+    add_index :assetable_galleries, [:galleryable_type, :galleryable_id], name: "poly_asset_gallery"
     add_index :assetable_galleries, [:galleryable_type, :galleryable_id, :name], unique: true, name: "named_gallery"
 
     add_index :assetable_galleries, :galleryable_id


### PR DESCRIPTION
I noticed that while working with this plugin in my development environment, migrations would fail because of the poly_asset index that is used in each of these migrations.  This just adds to the names so that they don't conflict.